### PR TITLE
Bump highlight.js dependency due to the EOL of version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yarn": "^1.0.0"
   },
   "dependencies": {
-    "highlight.js": "^9.0.0"
+    "highlight.js": "^10.4.0"
   },
   "devDependencies": {
     "@asciidoctor/core": ">=2.0.0 <2.2.0",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -19,10 +19,10 @@ const testCases = {
     attributes: { 'source-highlighter': 'html-pipeline' },
     given: `
       [source, ruby]
-      puts 'Hello, world!'
+      puts &#x27;Hello, world!&#x27;
     `,
     expected: `
-      puts 'Hello, world!'
+      puts &amp;#x27;Hello, world!&amp;#x27;
     `,
   },
 
@@ -43,7 +43,7 @@ const testCases = {
       puts 'Hello, world!'
     `,
     expected: `
-      <span class="hljs-attribute">puts</span> <span class="hljs-string">'Hello, world!'</span>
+      <span class="hljs-attribute">puts</span> <span class="hljs-string">&#x27;Hello, world!&#x27;</span>
     `,
   },
 
@@ -81,7 +81,7 @@ const testCases = {
       puts 'Hello, world!'
     `,
     expected: `
-      puts <span class="hljs-string">'Hello, world!'</span>
+      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>
     `,
   },
 
@@ -93,7 +93,7 @@ const testCases = {
       puts 'Hello, world!'
     `,
     expected: `
-      puts <span class="hljs-string">'Hello, world!'</span>
+      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>
     `,
   },
 
@@ -105,7 +105,7 @@ const testCases = {
       puts "{message}"
     `,
     expected: `
-      puts <span class="hljs-string">"Hello, #{subject}!"</span>
+      puts <span class="hljs-string">&quot;Hello, #{subject}!&quot;</span>
     `,
   },
 
@@ -117,7 +117,7 @@ const testCases = {
       puts "{message}"
     `,
     expected: `
-      puts <span class="hljs-string">"Hello, <span class="hljs-subst">#{subject}</span>!"</span>
+      puts <span class="hljs-string">&quot;Hello, <span class="hljs-subst">#{subject}</span>!&quot;</span>
     `,
   },
 
@@ -132,10 +132,10 @@ const testCases = {
       ----
     `,
     expected: `
-      <span class="hljs-keyword">require</span> <span class="hljs-string">'asciidoctor'</span>  <b class="conum">(1)</b>
+      <span class="hljs-keyword">require</span> <span class="hljs-string">&#x27;asciidoctor&#x27;</span>  <b class="conum">(1)</b>
 
-      puts <span class="hljs-string">'Hello, world!'</span>    &lt;<span class="hljs-number">3</span>&gt;<b class="conum">(2)</b>
-      puts <span class="hljs-string">'How are you?'</span>
+      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>    &lt;<span class="hljs-number">3</span>&gt;<b class="conum">(2)</b>
+      puts <span class="hljs-string">&#x27;How are you?&#x27;</span>
     `,
   },
 
@@ -145,7 +145,7 @@ const testCases = {
       puts '+++<strong>Oh hai!</strong>+++'
     `,
     expected: `
-      puts <span class="hljs-string">'<strong>Oh hai!</strong>'</span>
+      puts <span class="hljs-string">&#x27;<strong>Oh hai!</strong>&#x27;</span>
     `,
   },
 }
@@ -168,7 +168,7 @@ test('Source block inside a table cell', t => {
     | This is a normal cell text
     a|
     [source, ruby]
-    puts "Hello from table!"
+    puts &quot;Hello from table!&quot;
     |====
   `)
 
@@ -177,7 +177,7 @@ test('Source block inside a table cell', t => {
     .getRows().getBody()[1][0]  // cell
     .getInnerDocument().getBlocks()[0]  // listing
     .getContent()
-  const expected = 'puts <span class="hljs-string">"Hello from table!"</span>'
+  const expected = 'puts &amp;quot;Hello from table!&amp;quot;'
 
   t.isEqual(actual, expected, `should render: ${expected}`)
   t.end()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,10 +1318,10 @@ has@^1.0.1, has@^1.0.3, has@~1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-highlight.js@^9.0.0:
-  version "9.15.10"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
-  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+highlight.js@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
+  integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
 
 hosted-git-info@^2.1.4:
   version "2.8.5"


### PR DESCRIPTION
There is a warning from highlight.js v9 library due to the End Of Support for version 9: https://github.com/highlightjs/highlight.js/issues/2877

This PR is just bumping the dependency to version 10. There are some changes affecting the output, so I've updated the tests.