### PR TITLE
allow multiple callouts in one comment line

### DIFF
--- a/src/calloutsSubstitutor.js
+++ b/src/calloutsSubstitutor.js
@@ -9,7 +9,7 @@ type Processor = Object  // Asciidoctor::Extensions::Processor
 const ESCAPE_CHAR = '\\'
 
 // Copied from Asciidoctor::CalloutExtractRx
-const EXTRACT_RX = /(?:(?:\/\/|#|--|;;) ?)?(\\)?<!?(|--)(\d+)\2>(?=(?: ?\\?<!?\2\d+\2>)*$)/
+const EXTRACT_RX = /(?:(?:\/\/|#|--|;;) ?)?(\\)?<!?(|--)(\d+)\2>(?=(?: ?\\?<!?\2\d+\2>)*$)/g
 
 // Copied from Asciidoctor::CalloutExtractRxt
 const EXTRACT_RXT = '(\\\\)?<()(\\d+)>(?=(?: ?\\\\?<\\d+>)*$)'
@@ -23,7 +23,7 @@ export default (processor: Processor, node: AbstractNode) => {
   let docCallouts
 
   const calloutRx = lineComment
-    ? new RegExp(`(?:${regexpEscape(lineComment)} )?${EXTRACT_RXT}`)
+    ? new RegExp(`(?:${regexpEscape(lineComment)} )?${EXTRACT_RXT}`, 'g')
     : EXTRACT_RX
 
   /**

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -139,6 +139,24 @@ const testCases = {
     `,
   },
 
+  'Source block with callouts with line-comment option': {
+    given: `
+      [source, ruby, line-comment=%]
+      ----
+      require 'asciidoctor'  % <1>
+
+      puts 'Hello, world!'   % <2> <3>
+      puts 'How are you?'
+      ----
+    `,
+    expected: `
+      <span class="hljs-keyword">require</span> <span class="hljs-string">&#x27;asciidoctor&#x27;</span>  <b class="conum">(1)</b>
+
+      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>    <b class="conum">(2)</b> <b class="conum">(3)</b>
+      puts <span class="hljs-string">&#x27;How are you?&#x27;</span>
+    `,
+  },
+
   'Source block with passthrough and macros substitution enabled': {
     given: `
       [source, ruby, subs="macros"]

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -134,7 +134,7 @@ const testCases = {
     expected: `
       <span class="hljs-keyword">require</span> <span class="hljs-string">&#x27;asciidoctor&#x27;</span>  <b class="conum">(1)</b>
 
-      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>    &lt;<span class="hljs-number">3</span>&gt;<b class="conum">(2)</b>
+      puts <span class="hljs-string">&#x27;Hello, world!&#x27;</span>    <b class="conum">(2)</b> <b class="conum">(3)</b>
       puts <span class="hljs-string">&#x27;How are you?&#x27;</span>
     `,
   },


### PR DESCRIPTION
The following code:

```
[source,ruby]
----
# <1> <2>
----
<1> Hi
<2> Ho
```

renders the following output

![image](https://user-images.githubusercontent.com/3957921/123327590-e0b96d00-d53a-11eb-9e4e-90f600ac84db.png)

while it renders with Asciidoctor the following output

![image](https://user-images.githubusercontent.com/3957921/123327681-faf34b00-d53a-11eb-97ea-b0503046e4bc.png)

This PR brings the code in-line with Asciidoctor, that is using gsub (global replacement), see https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/substitutors.rb#L1358 

```
     line.gsub callout_rx do
        # honor the escape
        if $2
          # use sub since it might be behind a line comment
          $&.sub RS, ''
        else
          (callout_marks[lineno] ||= []) << [$1 || ($3 == '--' ? ['<!--', '-->'] : nil), $4 == '.' ? (autonum += 1).to_s : $4]
          last_lineno = lineno
          ''
        end
```